### PR TITLE
fix:replace enable conf to disable

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -44,7 +44,7 @@ type Tikv struct {
 
 // TikvGC config is the config of implement tikv sdk gcwork
 type TikvGC struct {
-	Enable            bool          `cfg:"enable; true; boolean; true for enabling tikv gc"`
+	Disable           bool          `cfg:"disable; false; boolean; false is used to disable tikvgc "`
 	Interval          time.Duration `cfg:"interval;20m;;gc work tick interval"`
 	LeaderLifeTime    time.Duration `cfg:"leader-life-time;30m;;lease flush leader interval"`
 	SafePointLifeTime time.Duration `cfg:"safe-point-life-time;10m;;safe point life time "`
@@ -53,7 +53,7 @@ type TikvGC struct {
 
 // GC config is the config of Titan GC work
 type GC struct {
-	Enable         bool          `cfg:"enable; true; boolean; true for enabling gc"`
+	Disable        bool          `cfg:"disable; false; boolean; false is used to disable gc"`
 	Interval       time.Duration `cfg:"interval;1s;;gc work tick interval"`
 	LeaderLifeTime time.Duration `cfg:"leader-life-time;3m;;lease flush leader interval"`
 	BatchLimit     int           `cfg:"batch-limit;256;numeric;key count limitation per-transection"`
@@ -61,7 +61,7 @@ type GC struct {
 
 // Expire config is the config of Titan expire work
 type Expire struct {
-	Enable         bool          `cfg:"enable; true; boolean; true for enabling expire"`
+	Disable        bool          `cfg:"disable; false; boolean; false is used to disable expire"`
 	Interval       time.Duration `cfg:"interval;1s;;expire work tick interval"`
 	LeaderLifeTime time.Duration `cfg:"leader-life-time;3m;;lease flush leader interval"`
 	BatchLimit     int           `cfg:"batch-limit;256;numeric;key count limitation per-transection"`
@@ -69,7 +69,7 @@ type Expire struct {
 
 // ZT config is the config of zlist
 type ZT struct {
-	Enable     bool          `cfg:"enable; true; boolean; true for enabling zt"`
+	Disable    bool          `cfg:"disable; false; boolean; false is used to disable  zt"`
 	Workers    int           `cfg:"workers;5;numeric;parallel workers count"`
 	BatchCount int           `cfg:"batch;10;numeric;object transfer limitation per-transection"`
 	QueueDepth int           `cfg:"depth;100;numeric;ZT Worker queue depth"`

--- a/conf/mockconfig.go
+++ b/conf/mockconfig.go
@@ -8,26 +8,26 @@ func MockConf() *Titan {
 		Tikv: Tikv{
 			PdAddrs: "mocktikv://",
 			GC: GC{
-				Enable:         true,
+				Disable:        false,
 				Interval:       time.Second,
 				LeaderLifeTime: 3 * time.Minute,
 				BatchLimit:     256,
 			},
 			Expire: Expire{
-				Enable:         true,
+				Disable:        false,
 				Interval:       time.Second,
 				LeaderLifeTime: 3 * time.Minute,
 				BatchLimit:     256,
 			},
 			ZT: ZT{
-				Enable:     true,
+				Disable:    false,
 				Workers:    5,
 				BatchCount: 10,
 				QueueDepth: 100,
 				Interval:   1000 * time.Millisecond,
 			},
 			TikvGC: TikvGC{
-				Enable:            true,
+				Disable:           false,
 				Interval:          20 * time.Minute,
 				LeaderLifeTime:    30 * time.Minute,
 				SafePointLifeTime: 10 * time.Minute,

--- a/conf/titan.toml
+++ b/conf/titan.toml
@@ -13,7 +13,7 @@ auth = ""
 #rules:       netaddr
 #description: address to listen
 #default:     0.0.0.0:7369
-listen = "0.0.0.0:7369"
+#listen = "0.0.0.0:7369"
 
 #type:        string
 #description: server SSL certificate file (enables SSL support)
@@ -27,13 +27,13 @@ ssl-key-file = ""
 #rules:       numeric
 #description: client connection count
 #default:     1000
-max-connection = 1000
+#max-connection = 1000
 
 #type:        int
 #rules:       numeric
 #description: the max limit length of elements in list
 #default:     100
-list-zip-threshold = 100
+#list-zip-threshold = 100
 
 
 [status]
@@ -58,7 +58,7 @@ ssl-key-file = ""
 #type:        string
 #description: pd address in tidb
 #required
-#mocktikv是内存模式
+##mocktikv是内存模式
 pd-addrs = "mocktikv://"
 
 [tikv.db]
@@ -76,9 +76,9 @@ pd-addrs = "mocktikv://"
 
 #type:        bool
 #rules:       boolean
-#description: true for enabling gc
-#default:     true
-#enable = true
+#description: false is used to disable gc
+#default:     false
+#disable = false
 
 #type:        time.Duration
 #description: gc work tick interval
@@ -101,9 +101,9 @@ pd-addrs = "mocktikv://"
 
 #type:        bool
 #rules:       boolean
-#description: true for enabling expire
-#default:     true
-#enable = true
+#description: false is used to disable expire
+#default:     false
+#disable = false
 
 #type:        time.Duration
 #description: expire work tick interval
@@ -126,9 +126,9 @@ pd-addrs = "mocktikv://"
 
 #type:        bool
 #rules:       boolean
-#description: true for enabling zt
-#default:     true
-#enable = true
+#description: false is used to disable  zt
+#default:     false
+#disable = false
 
 #type:        int
 #rules:       numeric
@@ -158,9 +158,9 @@ pd-addrs = "mocktikv://"
 
 #type:        bool
 #rules:       boolean
-#description: true for enabling tikv gc
-#default:     true
-#enable = true
+#description: false is used to disable tikvgc
+#default:     false
+#disable = false
 
 #type:        time.Duration
 #description: gc work tick interval

--- a/db/expire.go
+++ b/db/expire.go
@@ -88,7 +88,7 @@ func StartExpire(db *DB, conf *conf.Expire) error {
 	defer ticker.Stop()
 	id := UUID()
 	for range ticker.C {
-		if !conf.Enable {
+		if conf.Disable {
 			continue
 		}
 		isLeader, err := isLeader(db, sysExpireLeader, id, conf.LeaderLifeTime)
@@ -159,7 +159,7 @@ func runExpire(db *DB, batchLimit int) {
 		ts := DecodeInt64(rawKey[expireTimestampOffset : expireTimestampOffset+8])
 		if ts > now {
 			if logEnv := zap.L().Check(zap.DebugLevel, "[Expire] not need to expire key"); logEnv != nil {
-				logEnv.Write( zap.String("raw-key", string(rawKey)), zap.Int64("last-timestamp", ts))
+				logEnv.Write(zap.String("raw-key", string(rawKey)), zap.Int64("last-timestamp", ts))
 			}
 			break
 		}

--- a/db/gc.go
+++ b/db/gc.go
@@ -155,7 +155,7 @@ func StartGC(db *DB, conf *conf.GC) {
 	defer ticker.Stop()
 	id := UUID()
 	for range ticker.C {
-		if !conf.Enable {
+		if conf.Disable {
 			continue
 		}
 		isLeader, err := isLeader(db, sysGCLeader, id, conf.LeaderLifeTime)

--- a/db/tikvgc.go
+++ b/db/tikvgc.go
@@ -27,7 +27,7 @@ func StartTikvGC(db *DB, tikvCfg *conf.TikvGC) {
 	uuid := UUID()
 	ctx := context.Background()
 	for range ticker.C {
-		if !tikvCfg.Enable {
+		if tikvCfg.Disable {
 			continue
 		}
 		isLeader, err := isLeader(db, sysTikvGCLeader, uuid, tikvCfg.LeaderLifeTime)

--- a/db/ztransfer.go
+++ b/db/ztransfer.go
@@ -208,7 +208,7 @@ func StartZT(db *DB, conf *conf.ZT) {
 	defer ticker.Stop()
 	id := UUID()
 	for range ticker.C {
-		if !conf.Enable {
+		if conf.Disable {
 			continue
 		}
 		isLeader, err := isLeader(db, sysZTLeader, id, sysZTLeaderFlushInterval)


### PR DESCRIPTION
Some of the configo issues make the enable configuration items unavailable with a default value of false. Rename enable to disable and change the default value to true