### PR TITLE
Cleanup the pending commands of a client when the txn is executed

### DIFF
--- a/client.go
+++ b/client.go
@@ -51,7 +51,7 @@ func (c *client) isEof() bool {
 
 // Write to conn and log error if needed
 func (c *client) Write(p []byte) (int, error) {
-	zap.L().Debug("write to client", zap.String("msg", string(p)))
+	zap.L().Debug("write to client", zap.Int64("clientid", c.cliCtx.ID), zap.String("msg", string(p)))
 	n, err := c.conn.Write(p)
 	if err != nil {
 		c.conn.Close()

--- a/command/transactions.go
+++ b/command/transactions.go
@@ -26,6 +26,7 @@ func Exec(ctx *Context) {
 		resp.ReplyArray(ctx.Out, 0)
 		return
 	}
+	ctx.Client.Commands = nil
 
 	// Has watch command been issued
 	watching := ctx.Client.Txn != nil
@@ -122,7 +123,6 @@ func Exec(ctx *Context) {
 		return
 	}
 
-	ctx.Client.Commands = nil
 
 	resp.ReplyArray(ctx.Out, size)
 	// run OnCommit that fill reply to outputs


### PR DESCRIPTION
fixes #126

When a transaction is executed with failure, the pending commands are not cleared.  If this client sends the next transaction, the last commands will be executed and replied.

PS: A transaction is a series of commands: `watch ... multi ... exec`