### PR TITLE
dockerfile: use alpine instead of scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /go/src/github.com/distributedio/titan
 RUN env GOOS=linux CGO_ENABLED=0 make
 
 # Executable image
-FROM scratch
+FROM alpine
 
 COPY --from=builder /go/src/github.com/distributedio/titan/titan /titan/bin/titan
 COPY --from=builder /go/src/github.com/distributedio/titan/conf/titan.toml /titan/conf/titan.toml


### PR DESCRIPTION
`scratch` image is too empty to debug, use `alpine` which contains some basic commands.