### PR TITLE
feat(resp): use BytesArray instead of BytesArrayOnce

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -79,12 +79,6 @@ func BytesArray(w io.Writer, a [][]byte) OnCommit {
 	}
 }
 
-func BytesArrayOnce(w io.Writer, a [][]byte) OnCommit {
-    return func() {
-        resp.ReplyStringArray(w, a)
-    }
-}
-
 // TxnCommand runs a command in transaction
 type TxnCommand func(ctx *Context, txn *db.Transaction) (OnCommit, error)
 

--- a/command/zsets.go
+++ b/command/zsets.go
@@ -90,7 +90,7 @@ func zAnyOrderRange(ctx *Context, txn *db.Transaction, positiveOrder bool) (OnCo
 		return nil, errors.New("ERR " + err.Error())
 	}
 	if !zset.Exist() {
-		return BytesArrayOnce(ctx.Out, nil), nil
+		return BytesArray(ctx.Out, nil), nil
 	}
 
 	items, err := zset.ZAnyOrderRange(start, stop, withScore, positiveOrder)
@@ -98,9 +98,9 @@ func zAnyOrderRange(ctx *Context, txn *db.Transaction, positiveOrder bool) (OnCo
 		return nil, errors.New("ERR " + err.Error())
 	}
 	if len(items) == 0 {
-		return BytesArrayOnce(ctx.Out, nil), nil
+		return BytesArray(ctx.Out, nil), nil
 	}
-	return BytesArrayOnce(ctx.Out, items), nil
+	return BytesArray(ctx.Out, items), nil
 }
 
 func ZRangeByScore(ctx *Context, txn *db.Transaction) (OnCommit, error) {
@@ -148,7 +148,7 @@ func zAnyOrderRangeByScore(ctx *Context, txn *db.Transaction, positiveOrder bool
 		return nil, errors.New("ERR " + err.Error())
 	}
 	if !zset.Exist() {
-		return BytesArrayOnce(ctx.Out, nil), nil
+		return BytesArray(ctx.Out, nil), nil
 	}
 
 	items, err := zset.ZAnyOrderRangeByScore(startScore, startInclude,
@@ -160,9 +160,9 @@ func zAnyOrderRangeByScore(ctx *Context, txn *db.Transaction, positiveOrder bool
 		return nil, errors.New("ERR " + err.Error())
 	}
 	if len(items) == 0 {
-		return BytesArrayOnce(ctx.Out, nil), nil
+		return BytesArray(ctx.Out, nil), nil
 	}
-	return BytesArrayOnce(ctx.Out, items), nil
+	return BytesArray(ctx.Out, items), nil
 }
 
 func ZRem(ctx *Context, txn *db.Transaction) (OnCommit, error) {

--- a/encoding/resp/resp.go
+++ b/encoding/resp/resp.go
@@ -26,9 +26,6 @@ func ReplyBulkString(w io.Writer, msg string) error {
 	return NewEncoder(w).BulkString(msg)
 }
 
-func ReplyStringArray(w io.Writer, msgs [][]byte) error {
-	return NewEncoder(w).BulkStrings(msgs)
-}
 // ReplyNullBulkString replies a null bulkstring
 func ReplyNullBulkString(w io.Writer) error {
 	return NewEncoder(w).NullBulkString()
@@ -119,22 +116,6 @@ func (r *Encoder) Integer(v int64) error {
 func (r *Encoder) Array(size int) error {
 	s := strconv.Itoa(size)
 	_, err := r.w.Write([]byte("*" + s + "\r\n"))
-	return err
-}
-
-func (r *Encoder) BulkStrings(strs [][]byte) error {
-	var result []byte
-	strsLength := strconv.Itoa(len(strs))
-	result = append(result, []byte("*" + strsLength + "\r\n")...)
-
-	var strLength string
-	var str string
-	for i := range strs {
-		str = string(strs[i])
-		strLength = strconv.Itoa(len(str))
-		result = append(result, []byte("$" + strLength + "\r\n" + str + "\r\n")...)
-	}
-	_, err := r.w.Write(result)
 	return err
 }
 


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

Closes #165 

Do not maintain two different functions that implementing the same feature. Improve the performance of `BytesArray` if necessary.