### PR TITLE
command: implement unlink command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ For fully supported command list vist [here](docs/command_list.md)
 | Connections  | Won't Fully Supported   |
 | Transactions | Supported               |
 | Server       | Not Fully Supported Yet |
-| Keys         | Not Fully Supported Yet |
+| Keys         | Supported               |
 | Strings      | Not Fully Supported Yet |
 | List         | Not Fully Supported Yet |
 | Hashes       | Supported               |

--- a/command/init.go
+++ b/command/init.go
@@ -49,6 +49,7 @@ func init() {
 		"exists":    Exists,
 		"keys":      Keys,
 		"del":       Delete,
+		"unlink":    Delete, // unlink is the same as del in design
 		"expire":    Expire,
 		"expireat":  ExpireAt,
 		"pexpire":   PExpire,
@@ -162,6 +163,7 @@ func init() {
 		"exists":    Desc{Proc: AutoCommit(Exists), Cons: Constraint{-2, flags("rF"), 1, -1, 1}},
 		"keys":      Desc{Proc: AutoCommit(Keys), Cons: Constraint{-2, flags("rS"), 0, 0, 0}},
 		"del":       Desc{Proc: AutoCommit(Delete), Cons: Constraint{-2, flags("w"), 1, -1, 1}},
+		"unlink":    Desc{Proc: AutoCommit(Delete), Cons: Constraint{-2, flags("w"), 1, -1, 1}},
 		"expire":    Desc{Proc: AutoCommit(Expire), Cons: Constraint{3, flags("wF"), 1, 1, 1}},
 		"expireat":  Desc{Proc: AutoCommit(ExpireAt), Cons: Constraint{3, flags("wF"), 1, 1, 1}},
 		"pexpire":   Desc{Proc: AutoCommit(PExpire), Cons: Constraint{3, flags("wF"), 1, 1, 1}},

--- a/docs/command_list.md
+++ b/docs/command_list.md
@@ -49,7 +49,7 @@
 - [ ] touch
 - [x] keys
 - [x] scan
-- [ ] unlink
+- [x] unlink
 
 ### Strings
 
@@ -212,8 +212,6 @@ ___NOTICE: commands beyond this table has already been fully supported___
 |---|---|---|
 |swapdb |Connections| |
 |slowlog |Server | |
-|touch  |Keys | |
-|unlink |Keys | |
 |bitcount|Strings||
 |bitfield|Strings||
 |bitop   |Strings||


### PR DESCRIPTION
Closes #105

unlink is the same as del in design, both purging the data in the
backgroud by GC for large object.

Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>