### PR TITLE
command: implement the extension command: escan

### DIFF
--- a/command/extension.go
+++ b/command/extension.go
@@ -1,0 +1,68 @@
+package command
+
+import (
+	"fmt"
+	"github.com/distributedio/titan/db"
+	"github.com/distributedio/titan/encoding/resp"
+	"math"
+	"strconv"
+)
+
+// Escan scan the expiration list
+// escan [from start] [to end] [count N]
+func Escan(ctx *Context, txn *db.Transaction) (OnCommit, error) {
+	var from, to, count int64
+	to = math.MaxInt64
+	count = 10
+	args := ctx.Args
+	if len(args)%2 != 0 {
+		return nil, ErrWrongArgs("escan")
+	}
+
+	var p *int64
+	for i := 0; i < len(args)-1; i++ {
+		switch args[i] {
+		case "from":
+			p = &from
+		case "to":
+			p = &to
+		case "count":
+			p = &count
+		default:
+			return nil, ErrSyntax
+		}
+		i++
+		val, err := strconv.ParseInt(args[i], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		*p = val
+	}
+	if from > to {
+		return nil, db.ErrOutOfRange
+	}
+	at, keys, err := db.ScanExpiration(txn, from, to, count)
+	if err != nil {
+		return nil, err
+	}
+	n := len(keys)
+	if n == 0 {
+		return BytesArray(ctx.Out, nil), nil
+	}
+	// set the last ts as cursor
+	cursor := fmt.Sprintf("%d", at[n-1])
+
+	// set cursor to 0 if there is no more results
+	if int64(n) < count {
+		cursor = "0"
+	}
+
+	return func() {
+		resp.ReplyArray(ctx.Out, 2)
+		resp.ReplyBulkString(ctx.Out, cursor)
+		resp.ReplyArray(ctx.Out, n)
+		for i := 0; i < n; i++ {
+			resp.ReplyBulkString(ctx.Out, fmt.Sprintf("%d %s", at[i], keys[i]))
+		}
+	}, nil
+}

--- a/command/init.go
+++ b/command/init.go
@@ -229,6 +229,6 @@ func init() {
 		"zscore":        Desc{Proc: AutoCommit(ZScore), Cons: Constraint{3, flags("rF"), 1, 1, 1}},
 
 		// extension commands
-		"escan": Desc{Proc: AutoCommit(Escan), Cons: Constraint{-1, flags(""), 0, 0, 0}},
+		"escan": Desc{Proc: AutoCommit(Escan), Cons: Constraint{-1, flags("rR"), 0, 0, 0}},
 	}
 }

--- a/command/init.go
+++ b/command/init.go
@@ -104,6 +104,9 @@ func init() {
 		"ZRem":          ZRem,
 		"zcard":         ZCard,
 		"zscore":        ZScore,
+
+		// extension commands
+		"escan": Escan,
 	}
 
 	// commands contains all commands that open to clients
@@ -224,5 +227,8 @@ func init() {
 		"zrem":          Desc{Proc: AutoCommit(ZRem), Cons: Constraint{-3, flags("wF"), 1, 1, 1}},
 		"zcard":         Desc{Proc: AutoCommit(ZCard), Cons: Constraint{2, flags("rF"), 1, 1, 1}},
 		"zscore":        Desc{Proc: AutoCommit(ZScore), Cons: Constraint{3, flags("rF"), 1, 1, 1}},
+
+		// extension commands
+		"escan": Desc{Proc: AutoCommit(Escan), Cons: Constraint{-1, flags(""), 0, 0, 0}},
 	}
 }

--- a/db/expire.go
+++ b/db/expire.go
@@ -278,6 +278,7 @@ func ScanExpiration(txn *Transaction, from, to, count int64) ([]int64, [][]byte,
 	if err != nil {
 		return nil, nil, err
 	}
+	defer iter.Close()
 	var at []int64
 	var keys [][]byte
 	for iter.Valid() && iter.Key().HasPrefix(expireKeyPrefix) && count > 0 {


### PR DESCRIPTION
Closes #46

Implement an extension command `escan` which scans the expiration list.

Usage:

```
escan [from ts] [to ts] [count N]

# scan the first 10 keys in the expiration list
> escan
> escan count 10
> escan from 0 count 10

# scan keys between ts1 and ts2  (unit is nanoseconds)
> escan from 0 to 1578660490175858196 count 20
```