### PR TITLE
config: use mocktikv:// as the default pd address

### DIFF
--- a/bin/titan/main.go
+++ b/bin/titan/main.go
@@ -48,6 +48,10 @@ func main() {
 	if pdAddrs != "" {
 		config.TiKV.PdAddrs = pdAddrs
 	}
+	if config.TiKV.PdAddrs == "mocktikv://" {
+		fmt.Println("Warning: Titan is running in memory mode, all the data would be cleared after the process exit.")
+		fmt.Println("The memory mode can only be used for experience, configure the tikv.pd-addrs to use the TiKV as a backend")
+	}
 
 	if err := ConfigureZap(config.Logger.Name, config.Logger.Path, config.Logger.Level,
 		config.Logger.TimeRotate, config.Logger.Compress); err != nil {

--- a/conf/config.go
+++ b/conf/config.go
@@ -23,7 +23,7 @@ type Server struct {
 
 // TiKV config is the config of tikv sdk
 type TiKV struct {
-	PdAddrs string     `cfg:"pd-addrs;required; ;pd address in tidb"`
+	PdAddrs string     `cfg:"pd-addrs; mocktikv://; ;pd address in tidb"`
 	GC      GC         `cfg:"gc"`
 	Expire  Expire     `cfg:"expire"`
 	ZT      ZT         `cfg:"zt"`

--- a/conf/titan.toml
+++ b/conf/titan.toml
@@ -39,8 +39,8 @@ ssl-key-file = ""
 
 [tikv]
 
-#type: string, description: pd address in tidb, required
-pd-addrs = ""
+#type: string, description: pd address in tidb, default: mocktikv://
+#pd-addrs = "mocktikv://"
 
 
 [tikv.gc]

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cznic/strutil v0.0.0-20171016134553-529a34b1c186 // indirect
 	github.com/cznic/y v0.0.0-20170802143616-045f81c6662a // indirect
 	github.com/dgraph-io/ristretto v0.0.1 // indirect
-	github.com/distributedio/configo v0.0.0-20190610140513-0d38d0d8590a
+	github.com/distributedio/configo v0.0.0-20200107073829-efd79b027816
 	github.com/distributedio/continuous v0.0.0-20190527021358-1768e41f22b9
 	github.com/elazarl/go-bindata-assetfs v1.0.0 // indirect
 	github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51 // indirect


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

It is inconvenient to deploy the whole TiKV cluster to try Titan, fortunately, we can use the `mocktikv` as a backend. This PR configures the titan.toml to use `mocktikv://` as the default address. 