### PR TITLE
返回PONG时应该使用Simple String

### DIFF
--- a/command/connection.go
+++ b/command/connection.go
@@ -42,7 +42,7 @@ func Ping(ctx *Context) {
 		resp.ReplyBulkString(ctx.Out, args[0])
 		return
 	}
-	resp.ReplyBulkString(ctx.Out, "PONG")
+	resp.ReplySimpleString(ctx.Out, "PONG")
 }
 
 // Select the logical database


### PR DESCRIPTION
根据redis源码[pong](https://github.com/antirez/redis/blob/3.2/src/server.c#L1384)，返回PONG时使用的是simple string，而不是bulk string