### PR TITLE
add_dump_redis_command

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/distributedio/titan/db"
 	"github.com/distributedio/titan/encoding/resp"
 	"github.com/distributedio/titan/metrics"
+	"github.com/distributedio/titan/tools/dump"
 	"github.com/shafreeck/retry"
 	"go.uber.org/zap"
 )
@@ -299,6 +300,18 @@ func (e *Executor) Execute(ctx *Context) {
 	Call(ctx)
 	cost := time.Since(start).Seconds()
 	metrics.GetMetrics().CommandCallHistogramVec.WithLabelValues(ctx.Client.Namespace, ctx.Name).Observe(cost)
+	if dump.RecordSeq != nil {
+		dump.RecordSeq <- &dump.Record{
+			StartTime:  start,
+			Cost:       cost,
+			TraceID:    ctx.TraceID,
+			NameSpace:  ctx.Client.Namespace,
+			Name:       ctx.Name,
+			Args:       ctx.Args,
+			RemoteAddr: ctx.Client.RemoteAddr,
+		}
+	}
+
 }
 
 // Desc describes a command with constraints

--- a/conf/config.go
+++ b/conf/config.go
@@ -13,12 +13,14 @@ type Titan struct {
 
 // Server config is the config of titan server
 type Server struct {
-	Auth             string `cfg:"auth;;;client connetion auth"`
-	Listen           string `cfg:"listen; 0.0.0.0:7369; netaddr; address to listen"`
-	SSLCertFile      string `cfg:"ssl-cert-file;;;server SSL certificate file (enables SSL support)"`
-	SSLKeyFile       string `cfg:"ssl-key-file;;;server SSL key file"`
-	MaxConnection    int64  `cfg:"max-connection;1000;numeric;client connection count"`
-	ListZipThreshold int    `cfg:"list-zip-threshold;100;numeric;the max limit length of elements in list"`
+	Auth                       string `cfg:"auth;;;client connetion auth"`
+	Listen                     string `cfg:"listen; 0.0.0.0:7369; netaddr; address to listen"`
+	SSLCertFile                string `cfg:"ssl-cert-file;;;server SSL certificate file (enables SSL support)"`
+	SSLKeyFile                 string `cfg:"ssl-key-file;;;server SSL key file"`
+	MaxConnection              int64  `cfg:"max-connection;1000;numeric;client connection count"`
+	ListZipThreshold           int    `cfg:"list-zip-threshold;100;numeric;the max limit length of elements in list"`
+	DumpRedisCommand           string `cfg:"dump-redis-command;./;;dump redis command and duration to file"`
+	DumpRedisCommandRotateSize int    `cfg:"dump-redis-command-rotate-size; 500;;dump redis command file rotate size"`
 }
 
 // TiKV config is the config of tikv sdk

--- a/conf/titan.toml
+++ b/conf/titan.toml
@@ -22,7 +22,11 @@ ssl-key-file = ""
 #type: int, rules: numeric, description: the max limit length of elements in list, default: 100
 #list-zip-threshold = 100
 
+#type: string, description: dump redis command and duration to file
+#dump-redis-command = "./dumplogs"
 
+#type: int, description: dump redis command file rotate size(MB)
+#dump-redis-command-rotate-size = 500
 
 [status]
 
@@ -40,7 +44,7 @@ ssl-key-file = ""
 [tikv]
 
 #type: string, description: pd address in tidb, default: mocktikv://
-#pd-addrs = "mocktikv://"
+pd-addrs = "mocktikv://"
 
 
 [tikv.gc]
@@ -138,7 +142,7 @@ ssl-key-file = ""
 #path = "logs/titan"
 
 #type: string, description: log level(debug, info, warn, error, panic, fatal), default: info
-#level = "info"
+level = "debug"
 
 #type: bool, rules: boolean, description: true for enabling log compress, default: false
 #compress = false

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/arthurkiller/rollingwriter v1.1.2
 	github.com/coreos/bbolt v1.3.3 // indirect
-	github.com/coreos/etcd v3.3.18+incompatible // indirect
+	github.com/coreos/etcd v3.3.18+incompatible
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/gofail v0.0.0-20190801230047-ad7f989257ca // indirect
 	github.com/cznic/golex v0.0.0-20181122101858-9c343928389c // indirect
@@ -34,6 +34,7 @@ require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/myesui/uuid v1.0.0 // indirect
+	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/onsi/ginkgo v1.7.0 // indirect
 	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/opentracing/opentracing-go v1.1.0 // indirect

--- a/titan.go
+++ b/titan.go
@@ -7,6 +7,7 @@ import (
 	"github.com/distributedio/titan/command"
 	"github.com/distributedio/titan/context"
 	"github.com/distributedio/titan/metrics"
+	"github.com/distributedio/titan/tools/dump"
 	"go.uber.org/zap"
 )
 
@@ -67,12 +68,14 @@ func (s *Server) ListenAndServe(addr string) error {
 
 //Stop the server
 func (s *Server) Stop() error {
+	dump.CloseDumpChan <- true
 	zap.L().Info("titan serve stop", zap.String("addr", s.lis.Addr().String()))
 	return s.lis.Close()
 }
 
 //GracefulStop the server, TODO close clients connections first
 func (s *Server) GracefulStop() error {
+	dump.CloseDumpChan <- true
 	zap.L().Info("titan serve graceful", zap.String("addr", s.lis.Addr().String()))
 	return s.lis.Close()
 }

--- a/tools/dump/dump.go
+++ b/tools/dump/dump.go
@@ -1,0 +1,98 @@
+package dump
+
+import (
+	"bufio"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/distributedio/titan/conf"
+	"github.com/natefinch/lumberjack"
+	"go.uber.org/zap"
+)
+
+const (
+	timeFormat      = "2006-01-02 15:04:05"
+	defaultFileSize = 500 // megabytes
+)
+
+//Record redis command information
+type Record struct {
+	StartTime  time.Time
+	Cost       float64
+	TraceID    string
+	Name       string
+	Args       []string
+	NameSpace  string
+	RemoteAddr string
+}
+
+var (
+	config    *conf.Server
+	nsFileMap map[string]*bufio.Writer
+	//RecordSeq all of redis command  transfer chan
+	RecordSeq chan *Record
+	//CloseDumpChan close dump chan
+	CloseDumpChan chan bool
+)
+
+//InitDumpCommand init dump command
+func InitDumpCommand(c *conf.Server) error {
+	config = c
+	RecordSeq = make(chan *Record, 1000000)
+	nsFileMap = make(map[string]*bufio.Writer)
+	CloseDumpChan = make(chan bool)
+	go loop()
+	zap.L().Info(fmt.Sprintf("init dump command successful."))
+	return nil
+}
+
+func newFile(namespace string) *bufio.Writer {
+	if config.DumpRedisCommandRotateSize == 0 {
+		config.DumpRedisCommandRotateSize = defaultFileSize
+	}
+	return bufio.NewWriter(&lumberjack.Logger{
+		Filename:   filepath.Join(config.DumpRedisCommand, namespace),
+		MaxSize:    config.DumpRedisCommandRotateSize, // megabytes
+		MaxBackups: 3000,
+		MaxAge:     3000, //days
+		Compress:   true, // disabled by default
+	})
+}
+
+func loop() {
+	for {
+		select {
+		case m := <-RecordSeq:
+			writeCommand(m)
+		case <-CloseDumpChan:
+			stop()
+			return
+		}
+	}
+}
+
+func writeCommand(m *Record) error {
+	w, ok := nsFileMap[m.NameSpace]
+	if !ok {
+		w = newFile(m.NameSpace)
+		nsFileMap[m.NameSpace] = w
+	}
+	_, err := w.WriteString(fmt.Sprintf("%s||%f||%s||%s||%s||%v\n",
+		m.StartTime.Local().Format(timeFormat), m.Cost, m.RemoteAddr, m.TraceID, m.Name, m.Args))
+	if err != nil {
+		zap.L().Info(fmt.Sprintf("write dump log error %v", err))
+	}
+	return nil
+}
+
+func stop() error {
+	close(RecordSeq)
+	for _, f := range nsFileMap {
+		f.Flush()
+	}
+	return nil
+}
+
+func init() {
+}


### PR DESCRIPTION
dump all namespace commands to separate files, which rotate by size.

We use titan as a platform for all teams.
Sometimes we want to know 
- which command with params is high latency, and hurt the platform
- for audits